### PR TITLE
3 - Add user_data parameter to interface callback

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libs/cjson/cJSON"]
+	path = libs/cjson/cJSON
+	url = https://github.com/DaveGamble/cJSON.git

--- a/include/k_ghost_io.h
+++ b/include/k_ghost_io.h
@@ -21,10 +21,11 @@ extern "C"
  * @brief Callback function type for handling specific interface requests.
  *
  * @param input_data_p Pointer to the input data for the callback, in cJSON format.
+ * @param user_data_p Pointer to provided user data.
  *
  * @return int Returns 0 on success, or -1 on failure.
  */
-typedef int (*k_ghost_io_interface_callback_t)(const cJSON *input_data_p);
+typedef int (*k_ghost_io_interface_callback_t)(const cJSON *input_data_p, void *user_data_p);
 
 /**
  * @brief Callback function type for synchronizing the status of the system.
@@ -51,6 +52,7 @@ typedef struct
 	char						   *interface_name;	 //!< Interface name this callback is used for
 	k_ghost_io_interface_callback_t rest_cb;		 //!< Callback to be used for the specific hardware interface type
 	k_ghost_io_sync_status_t		sync_cb;		 //!< Callback to be used for synchronizing the status of the system with the SSE clients
+	void						   *user_data_p;	 //!< User data to be passed to the callback
 	void						   *next_cb;		 //!< Pointer to the next REST API callback in the list
 } k_ghost_io_interface_t;
 
@@ -70,11 +72,12 @@ int k_ghost_io_init(void);
  * @param interface_name Name of the interface to register.
  * @param rest_cb Callback function for handling REST requests for this interface.
  * @param sync_cb Optional. Callback function for synchronizing the status of the system with the SSE clients.
+ * @param user_data_p Optional. Pointer to user data to pass to callback.
  *
  * @return Returns registration status code. Refer to k_ghost_io_register_ret_code_t for possible values.
  */
 k_ghost_io_register_ret_code_t k_ghost_io_register_interface(const char *interface_name, k_ghost_io_interface_callback_t rest_cb,
-															 k_ghost_io_sync_status_t sync_cb);
+															 k_ghost_io_sync_status_t sync_cb, void *user_data_p);
 
 /**
  * @brief Send the data payload to be sent via SSE to connected clients

--- a/mock/k_ghost_io_mock.c
+++ b/mock/k_ghost_io_mock.c
@@ -14,5 +14,6 @@
 /* Variable ------------------------------------------------------------------*/
 /* Function Definition -------------------------------------------------------*/
 DEFINE_FAKE_VALUE_FUNC(int, k_ghost_io_init)
-DEFINE_FAKE_VALUE_FUNC(k_ghost_io_register_ret_code_t, k_ghost_io_register_interface, const char *, k_ghost_io_interface_callback_t, k_ghost_io_sync_status_t)
+DEFINE_FAKE_VALUE_FUNC(k_ghost_io_register_ret_code_t, k_ghost_io_register_interface, const char *, k_ghost_io_interface_callback_t, k_ghost_io_sync_status_t,
+					   void *)
 DEFINE_FAKE_VOID_FUNC(k_ghost_io_send_event, const char *)

--- a/mock/k_ghost_io_mock.h
+++ b/mock/k_ghost_io_mock.h
@@ -1,5 +1,5 @@
 /**
-* @brief Mock for k_ghost_io library
+ * @brief Mock for k_ghost_io library
  * @addtogroup k_ghost_io_mock
  * @{
  */
@@ -10,20 +10,20 @@ extern "C"
 {
 #endif
 
-	/* Include -------------------------------------------------------------------*/
+/* Include -------------------------------------------------------------------*/
 #include "fff.h"
 #include "k_ghost_io.h"
-	/* Macro ---------------------------------------------------------------------*/
-	/* Typedef -------------------------------------------------------------------*/
-	/* Constant ------------------------------------------------------------------*/
-	/* Variable ------------------------------------------------------------------*/
-	/* Function Declaration ------------------------------------------------------*/
-	DECLARE_FAKE_VALUE_FUNC(int, k_ghost_io_init)
-	DECLARE_FAKE_VALUE_FUNC(k_ghost_io_register_ret_code_t, k_ghost_io_register_interface, const char *, k_ghost_io_interface_callback_t,
-																 k_ghost_io_sync_status_t)
+/* Macro ---------------------------------------------------------------------*/
+/* Typedef -------------------------------------------------------------------*/
+/* Constant ------------------------------------------------------------------*/
+/* Variable ------------------------------------------------------------------*/
+/* Function Declaration ------------------------------------------------------*/
+DECLARE_FAKE_VALUE_FUNC(int, k_ghost_io_init)
+DECLARE_FAKE_VALUE_FUNC(k_ghost_io_register_ret_code_t, k_ghost_io_register_interface, const char *, k_ghost_io_interface_callback_t, k_ghost_io_sync_status_t,
+						void *)
 DECLARE_FAKE_VOID_FUNC(k_ghost_io_send_event, const char *)
 
-	#ifdef __cplusplus
-	}
+#ifdef __cplusplus
+}
 #endif
 /* @} */

--- a/src/linux/k_ghost_io.c
+++ b/src/linux/k_ghost_io.c
@@ -91,7 +91,7 @@ int k_ghost_io_init(void)
 }
 
 k_ghost_io_register_ret_code_t k_ghost_io_register_interface(const char *interface_name, k_ghost_io_interface_callback_t rest_cb,
-															 k_ghost_io_sync_status_t sync_cb)
+															 k_ghost_io_sync_status_t sync_cb, void *user_data_p)
 {
 	k_ghost_io_register_ret_code_t ret_code = K_GHOST_REGISTER_RET_CODE_ERROR;
 	if (interface_name && rest_cb)
@@ -114,6 +114,7 @@ k_ghost_io_register_ret_code_t k_ghost_io_register_interface(const char *interfa
 				new_interface->interface_name = strdup(interface_name);
 				new_interface->rest_cb		  = rest_cb;
 				new_interface->sync_cb		  = sync_cb;
+				new_interface->user_data_p	  = user_data_p;
 				new_interface->next_cb		  = k_ghost_io_ctx.interfaces;
 				k_ghost_io_ctx.interfaces	  = new_interface;
 				ret_code					  = K_GHOST_REGISTER_RET_CODE_OK;
@@ -315,7 +316,7 @@ void k_ghost_io_manage_rest_request(int client_fd, const char *request)
 						if (0 == strcmp(interface_p->interface_name, interface))
 						{
 							interface_found = 1;
-							int ret_code	= interface_p->rest_cb(json_request);
+							int ret_code	= interface_p->rest_cb(json_request, interface_p->user_data_p);
 							if (0 == ret_code)
 							{
 								const char *resp = "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";


### PR DESCRIPTION
Enhance the `k_ghost_io_register_interface` function to include user data parameters. 
Adjust related tests and mocks for compatibility.
Add .gitmodules files to version control